### PR TITLE
Add .gitattributes to fix language analysis

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.cpp linguist-vendored

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 *.cpp linguist-vendored
 port/cpp/* linguist-vendored
+*.go linguist-language=go

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.cpp linguist-vendored
+port/cpp/* linguist-vendored

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
 *.cpp linguist-vendored
 port/cpp/* linguist-vendored
-*.go linguist-language=go
+*.go -linguist-generated


### PR DESCRIPTION
Currently the repo appears to be C++ due to the way GitHub's Linguist analysis omits generated files.  This PR adds a `.gitattributes` file which correct this.